### PR TITLE
Make unzipLazy strict in its result components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Revision history for unzip-traversable
 
-## 0.1.0.0 -- YYYY-mm-dd
+## 0.1.1 -- 2025-07-02
+
+* Make `unzipLazy` and `unzipLazyWith` strict in the components of their results.
+  This is needed to get reasonably consistent behavior. Fixes #2.
+
+## 0.1 -- 2025-07-01
 
 * First version. Released on an unsuspecting world.

--- a/src/Data/Traversable/Unzip.hs
+++ b/src/Data/Traversable/Unzip.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE Trustworthy #-}  -- For safe coercions
 
 -- | Suppose you have a container of pairs, @abs :: T (a, b)@, and you wish to
@@ -25,7 +26,7 @@
 -- problems: the structure is traversed lazily or eagerly, only once, and in
 -- the lazy case great care is taken to avoid space leaks.
 --
--- === Note
+-- === Note on lists
 --
 -- @"Data.List".'Data.List.unzip'@ has a nifty partially-lazy implementation
 -- that inspects list conses only as needed, but pulls apart the pairs stored
@@ -58,6 +59,19 @@ import Data.Biapplicative (traverseBia)
 -- result will be bottom.
 --
 -- @unzipEager [⊥] = ⊥@
+--
+-- This function could be defined to operate in two passes thus:
+--
+-- @
+-- unzipEager p
+--   | 'Data.Tuple.MkSolo' as \<- 'traverse' (\\(a, _) -> 'Data.Tuple.MkSolo' a) $ p
+--   , 'Data.Tuple.MkSolo' bs \<- 'traverse' (\\(_, b) -> 'Data.Tuple.MkSolo' b) $ p
+-- = (as, bs)
+-- @
+--
+-- Indeed, there are probably situations where the two-pass version will be
+-- more efficient!  This is especially likely when the container is fairly
+-- small and is of a type not in the @base@ package.
 unzipEager :: Traversable t => t (a, b) -> (t a, t b)
 unzipEager x = unzipEagerWith id x
 
@@ -68,9 +82,12 @@ unzipEagerWith f = unEagerPair #. traverseBia (EagerPair #. f)
 
 -- | An unzipping function that works for any `Traversable` type. The results
 -- are as lazy as possible for the underlying `Traversable` instance. The
--- result is always lazy in the pairs. The result pair is produced eagerly.
+-- result is always lazy in the pairs contained in the argument. Both
+-- components of the result are reduced to weak head normal form.
 --
--- @unzipLazy ⊥ = ⊥@
+-- @unzipLazy p = case 'unzipExtraLazy' p of r\@(!_, !_) -> r@
+--
+-- @unzipLazy ⊥ = ⊥ -- (for strictly lawful instances)@
 --
 -- @unzipLazy [⊥, ⊥] = ([⊥, ⊥], [⊥, ⊥])@
 --
@@ -79,7 +96,8 @@ unzipLazy :: Traversable t => t (a, b) -> (t a, t b)
 unzipLazy x = unzipLazyWith id x
 
 -- | A version of @unzipLazy@ that produces the result pair lazily, exactly like
--- @"Data.Functor".'Data.Functor.unzip'@.
+-- @"Data.Functor".'Data.Functor.unzip'@. We take special care to avoid leaking
+-- inaccessible values.
 --
 -- @unzipExtraLazy xs = "Data.Functor".'Data.Functor.unzip' xs@
 --
@@ -92,7 +110,30 @@ unzipExtraLazy x = unzipExtraLazyWith id x
 -- | A version of 'unzipLazy' that takes a function to use to produce the
 -- pairs.
 unzipLazyWith :: Traversable t => (a -> (b, c)) -> t a -> (t b, t c)
-unzipLazyWith f = unLazyPair . traverseBia (LazyPair #. f)
+-- See [Note: unzipLazy strictness, below]
+unzipLazyWith f = strictifyPair . unLazyPair . traverseBia (LazyPair #. f)
+
+-- Note: unzipLazy strictness
+--
+-- It might seem surprising that we force the components of the result.
+-- Unfortunately, if we didn't do so, then @unzipLazy ⊥@ could be bottom or not
+-- depending on details of the `Traversable` instance for the type in question
+-- that users would almost certainly find surprising. For example, consider
+--
+--   newtype Foo a = Foo [a] deriving (Functor, Foldable, Traversable)
+--
+-- If we didn't force the components, then we'd have
+--
+--   unzipLazy (undefined @[Int]) = ⊥
+--
+--   unzipLazy (undefined @(Foo Int)) = (⊥, ⊥)
+--
+-- Why would this happen? Because there's a final bimap in the traversal to
+-- apply the newtype constructors, and the Bifunctor instance for LazyPair
+-- introduces laziness there!
+--
+-- Technically, we only need to force one of the components, but forcing both
+-- seems a bit simpler and probably easier on the compiler.
 
 -- | A version of 'unzipExtraLazy' that takes a function to use to produce the
 -- pairs.
@@ -102,3 +143,7 @@ unzipExtraLazyWith f = ensurePair . unLazyPair . traverseBia (LazyPair #. f)
 -- Make a pair lazy
 ensurePair :: (a, b) -> (a, b)
 ensurePair ~(a, b) = (a, b)
+
+-- Make a pair extra strict
+strictifyPair :: (a, b) -> (a, b)
+strictifyPair p@(!_, !_) = p

--- a/unzip-traversable.cabal
+++ b/unzip-traversable.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               unzip-traversable
-version:            0.1
+version:            0.1.1
 synopsis:           Unzip functions for general Traversable containers
 description:
   This package provides functions for unzipping arbitrary `Traversable`


### PR DESCRIPTION
Previously, `unzipLazy` and `unzipLazyWith` could be somewhat bizarrely lazy, thanks to laziness introduced to the "outside" of the traversal. Make both of them force the components of their results to WHNF.

Fixes #2